### PR TITLE
Relax pragma in SafeMath to match other library files

### DIFF
--- a/contracts/libraries/SafeMath.sol
+++ b/contracts/libraries/SafeMath.sol
@@ -1,4 +1,4 @@
-pragma solidity =0.6.6;
+pragma solidity >=0.5.0;
 
 // a library for performing overflow-safe math, courtesy of DappHub (https://github.com/dapphub/ds-math)
 


### PR DESCRIPTION
- With "=0.6.6" you need to be using this exact solidity compiler version to use UniswapV2Library.sol

- See discussion in the following PRs:
  https://github.com/Uniswap/uniswap-v2-core/pull/71
  https://github.com/Uniswap/uniswap-v2-periphery/pull/10