### PR TITLE
Fix: getAmountIn() incorrect function call

### DIFF
--- a/contracts/UniswapV2Router01.sol
+++ b/contracts/UniswapV2Router01.sol
@@ -267,7 +267,7 @@ contract UniswapV2Router01 is IUniswapV2Router01 {
     }
 
     function getAmountIn(uint amountOut, uint reserveIn, uint reserveOut) public pure override returns (uint amountIn) {
-        return UniswapV2Library.getAmountOut(amountOut, reserveIn, reserveOut);
+        return UniswapV2Library.getAmountIn(amountOut, reserveIn, reserveOut);
     }
 
     function getAmountsOut(uint amountIn, address[] memory path) public view override returns (uint[] memory amounts) {


### PR DESCRIPTION
UniswapV2Library's getAmountIn() function needs to be called instead of getAmountOut()