### PR TITLE
change memory to calldata

### DIFF
--- a/contracts/UniswapV2Router01.sol
+++ b/contracts/UniswapV2Router01.sol
@@ -166,7 +166,7 @@ contract UniswapV2Router01 is IUniswapV2Router01 {
 
     // **** SWAP ****
     // requires the initial amount to have already been sent to the first pair
-    function _swap(uint[] memory amounts, address[] memory path, address _to) private {
+    function _swap(uint[] calldata amounts, address[] memory path, address _to) private {
         for (uint i; i < path.length - 1; i++) {
             (address input, address output) = (path[i], path[i + 1]);
             (address token0,) = UniswapV2Library.sortTokens(input, output);

--- a/contracts/UniswapV2Router02.sol
+++ b/contracts/UniswapV2Router02.sol
@@ -209,7 +209,7 @@ contract UniswapV2Router02 is IUniswapV2Router02 {
 
     // **** SWAP ****
     // requires the initial amount to have already been sent to the first pair
-    function _swap(uint[] memory amounts, address[] memory path, address _to) internal virtual {
+    function _swap(uint[] calldata amounts, address[] memory path, address _to) internal virtual {
         for (uint i; i < path.length - 1; i++) {
             (address input, address output) = (path[i], path[i + 1]);
             (address token0,) = UniswapV2Library.sortTokens(input, output);


### PR DESCRIPTION
Changing the data location of function parameters from memory to calldata can save much gas.
In the following example, test4 saves about 955 units of gas.

```
    function test3(uint256[] memory amounts) public {
        uint256 amount = amounts[0];
    }

    function test4(uint256[] calldata amounts) public {
        uint256 amount = amounts[0];
    }
```