### PR TITLE
change memory to calldata to save gas

### DIFF
--- a/contracts/UniswapV2Router01.sol
+++ b/contracts/UniswapV2Router01.sol
@@ -270,11 +270,11 @@ contract UniswapV2Router01 is IUniswapV2Router01 {
         return UniswapV2Library.getAmountOut(amountOut, reserveIn, reserveOut);
     }
 
-    function getAmountsOut(uint amountIn, address[] memory path) public view override returns (uint[] memory amounts) {
+    function getAmountsOut(uint amountIn, address[] calldata path) public view override returns (uint[] memory amounts) {
         return UniswapV2Library.getAmountsOut(factory, amountIn, path);
     }
 
-    function getAmountsIn(uint amountOut, address[] memory path) public view override returns (uint[] memory amounts) {
+    function getAmountsIn(uint amountOut, address[] calldata path) public view override returns (uint[] memory amounts) {
         return UniswapV2Library.getAmountsIn(factory, amountOut, path);
     }
 }

--- a/contracts/UniswapV2Router02.sol
+++ b/contracts/UniswapV2Router02.sol
@@ -424,7 +424,7 @@ contract UniswapV2Router02 is IUniswapV2Router02 {
         return UniswapV2Library.getAmountIn(amountOut, reserveIn, reserveOut);
     }
 
-    function getAmountsOut(uint amountIn, address[] memory path)
+    function getAmountsOut(uint amountIn, address[] calldata path)
         public
         view
         virtual
@@ -434,7 +434,7 @@ contract UniswapV2Router02 is IUniswapV2Router02 {
         return UniswapV2Library.getAmountsOut(factory, amountIn, path);
     }
 
-    function getAmountsIn(uint amountOut, address[] memory path)
+    function getAmountsIn(uint amountOut, address[] calldata path)
         public
         view
         virtual


### PR DESCRIPTION
Changing the data location of function parameters from memory to calldata can save much gas.
In the following example, test4 saves about 955 units of gas.

```
    function test3(uint256[] memory amounts) public {
        uint256 amount = amounts[0];
    }

    function test4(uint256[] calldata amounts) public {
        uint256 amount = amounts[0];
    }
```