### PR TITLE
move loop invariant codes out from loop to save gas

### DIFF
--- a/contracts/UniswapV2Router01.sol
+++ b/contracts/UniswapV2Router01.sol
@@ -167,12 +167,19 @@ contract UniswapV2Router01 is IUniswapV2Router01 {
     // **** SWAP ****
     // requires the initial amount to have already been sent to the first pair
     function _swap(uint[] memory amounts, address[] memory path, address _to) private {
-        for (uint i; i < path.length - 1; i++) {
-            (address input, address output) = (path[i], path[i + 1]);
-            (address token0,) = UniswapV2Library.sortTokens(input, output);
-            uint amountOut = amounts[i + 1];
-            (uint amount0Out, uint amount1Out) = input == token0 ? (uint(0), amountOut) : (amountOut, uint(0));
-            address to = i < path.length - 2 ? UniswapV2Library.pairFor(factory, output, path[i + 2]) : _to;
+        address input; 
+        address output;
+        address token0;
+        uint amountOut;
+        uint amount0Out; 
+        uint amount1Out;
+        uint256 len = path.length;
+        for (uint i; i < len - 1; i++) {
+            (input, output) = (path[i], path[i + 1]);
+            (token0,) = UniswapV2Library.sortTokens(input, output);
+            amountOut = amounts[i + 1];
+            (amount0Out, amount1Out) = input == token0 ? (uint(0), amountOut) : (amountOut, uint(0));
+            address to = i < len - 2 ? UniswapV2Library.pairFor(factory, output, path[i + 2]) : _to;
             IUniswapV2Pair(UniswapV2Library.pairFor(factory, input, output)).swap(amount0Out, amount1Out, to, new bytes(0));
         }
     }

--- a/contracts/UniswapV2Router02.sol
+++ b/contracts/UniswapV2Router02.sol
@@ -332,10 +332,6 @@ contract UniswapV2Router02 is IUniswapV2Router02 {
         IUniswapV2Pair pair;
         uint amountInput;
         uint amountOutput;
-        uint reserve0; 
-        uint reserve1;
-        uint reserveInput; 
-        uint reserveOutput;
         uint amount0Out; 
         uint amount1Out;
         uint256 len = path.length;
@@ -345,8 +341,8 @@ contract UniswapV2Router02 is IUniswapV2Router02 {
             pair = IUniswapV2Pair(UniswapV2Library.pairFor(factory, input, output));
             
             { // scope to avoid stack too deep errors
-            (reserve0, reserve1,) = pair.getReserves();
-            (reserveInput, reserveOutput) = input == token0 ? (reserve0, reserve1) : (reserve1, reserve0);
+            (uint reserve0, uint reserve1,) = pair.getReserves();
+            (uint reserveInput, uint reserveOutput) = input == token0 ? (reserve0, reserve1) : (reserve1, reserve0);
             amountInput = IERC20(input).balanceOf(address(pair)).sub(reserveInput);
             amountOutput = UniswapV2Library.getAmountOut(amountInput, reserveInput, reserveOutput);
             }

--- a/contracts/UniswapV2Router02.sol
+++ b/contracts/UniswapV2Router02.sol
@@ -210,12 +210,19 @@ contract UniswapV2Router02 is IUniswapV2Router02 {
     // **** SWAP ****
     // requires the initial amount to have already been sent to the first pair
     function _swap(uint[] memory amounts, address[] memory path, address _to) internal virtual {
-        for (uint i; i < path.length - 1; i++) {
-            (address input, address output) = (path[i], path[i + 1]);
-            (address token0,) = UniswapV2Library.sortTokens(input, output);
-            uint amountOut = amounts[i + 1];
-            (uint amount0Out, uint amount1Out) = input == token0 ? (uint(0), amountOut) : (amountOut, uint(0));
-            address to = i < path.length - 2 ? UniswapV2Library.pairFor(factory, output, path[i + 2]) : _to;
+        address input; 
+        address output;
+        address token0;
+        uint amountOut;
+        uint amount0Out; 
+        uint amount1Out;
+        uint256 len = path.length;
+        for (uint i; i < len - 1; i++) {
+            (input, output) = (path[i], path[i + 1]);
+            (token0,) = UniswapV2Library.sortTokens(input, output);
+            amountOut = amounts[i + 1];
+            (amount0Out, amount1Out) = input == token0 ? (uint(0), amountOut) : (amountOut, uint(0));
+            address to = i < len - 2 ? UniswapV2Library.pairFor(factory, output, path[i + 2]) : _to;
             IUniswapV2Pair(UniswapV2Library.pairFor(factory, input, output)).swap(
                 amount0Out, amount1Out, to, new bytes(0)
             );
@@ -319,20 +326,32 @@ contract UniswapV2Router02 is IUniswapV2Router02 {
     // **** SWAP (supporting fee-on-transfer tokens) ****
     // requires the initial amount to have already been sent to the first pair
     function _swapSupportingFeeOnTransferTokens(address[] memory path, address _to) internal virtual {
-        for (uint i; i < path.length - 1; i++) {
-            (address input, address output) = (path[i], path[i + 1]);
-            (address token0,) = UniswapV2Library.sortTokens(input, output);
-            IUniswapV2Pair pair = IUniswapV2Pair(UniswapV2Library.pairFor(factory, input, output));
-            uint amountInput;
-            uint amountOutput;
+        address input; 
+        address output;
+        address token0;
+        IUniswapV2Pair pair;
+        uint amountInput;
+        uint amountOutput;
+        uint reserve0; 
+        uint reserve1;
+        uint reserveInput; 
+        uint reserveOutput;
+        uint amount0Out; 
+        uint amount1Out;
+        uint256 len = path.length;
+        for (uint i; i < len - 1; i++) {
+            (input, output) = (path[i], path[i + 1]);
+            (token0,) = UniswapV2Library.sortTokens(input, output);
+            pair = IUniswapV2Pair(UniswapV2Library.pairFor(factory, input, output));
+            
             { // scope to avoid stack too deep errors
-            (uint reserve0, uint reserve1,) = pair.getReserves();
-            (uint reserveInput, uint reserveOutput) = input == token0 ? (reserve0, reserve1) : (reserve1, reserve0);
+            (reserve0, reserve1,) = pair.getReserves();
+            (reserveInput, reserveOutput) = input == token0 ? (reserve0, reserve1) : (reserve1, reserve0);
             amountInput = IERC20(input).balanceOf(address(pair)).sub(reserveInput);
             amountOutput = UniswapV2Library.getAmountOut(amountInput, reserveInput, reserveOutput);
             }
-            (uint amount0Out, uint amount1Out) = input == token0 ? (uint(0), amountOutput) : (amountOutput, uint(0));
-            address to = i < path.length - 2 ? UniswapV2Library.pairFor(factory, output, path[i + 2]) : _to;
+            (amount0Out, amount1Out) = input == token0 ? (uint(0), amountOutput) : (amountOutput, uint(0));
+            address to = i < len - 2 ? UniswapV2Library.pairFor(factory, output, path[i + 2]) : _to;
             pair.swap(amount0Out, amount1Out, to, new bytes(0));
         }
     }

--- a/contracts/libraries/UniswapV2Library.sol
+++ b/contracts/libraries/UniswapV2Library.sol
@@ -60,11 +60,14 @@ library UniswapV2Library {
 
     // performs chained getAmountOut calculations on any number of pairs
     function getAmountsOut(address factory, uint amountIn, address[] memory path) internal view returns (uint[] memory amounts) {
-        require(path.length >= 2, 'UniswapV2Library: INVALID_PATH');
-        amounts = new uint[](path.length);
+        uint256 len = path.length;
+        require(len >= 2, 'UniswapV2Library: INVALID_PATH');
+        amounts = new uint[](len);
         amounts[0] = amountIn;
-        for (uint i; i < path.length - 1; i++) {
-            (uint reserveIn, uint reserveOut) = getReserves(factory, path[i], path[i + 1]);
+        uint reserveIn; 
+        uint reserveOut;
+        for (uint i; i < len - 1; i++) {
+            (reserveIn, reserveOut) = getReserves(factory, path[i], path[i + 1]);
             amounts[i + 1] = getAmountOut(amounts[i], reserveIn, reserveOut);
         }
     }
@@ -74,8 +77,10 @@ library UniswapV2Library {
         require(path.length >= 2, 'UniswapV2Library: INVALID_PATH');
         amounts = new uint[](path.length);
         amounts[amounts.length - 1] = amountOut;
+        uint reserveIn; 
+        uint reserveOut;
         for (uint i = path.length - 1; i > 0; i--) {
-            (uint reserveIn, uint reserveOut) = getReserves(factory, path[i - 1], path[i]);
+            (reserveIn, reserveOut) = getReserves(factory, path[i - 1], path[i]);
             amounts[i - 1] = getAmountIn(amounts[i], reserveIn, reserveOut);
         }
     }


### PR DESCRIPTION
Moving loop invariant codes out from loop can save gas.
In the following demo, it can save 265 units of gas when the length of ```arr``` is 100.
```
    function test1(uint256[] memory arr) public {     
        for(uint256 i = 0; i < arr.length; i++) {
        }
    }

    function test2(uint256[] memory arr) public {
        uint256 len = arr.length;
        for(uint256 i = 0; i < len; i++) {
        }
    }
```
Initializing variables before the loop instead of inside the loop can also save gas. In the example below, function test4 consumes 553 units less gas than function test3 when the length of arr is 100.
```
    function test3(uint256[] memory arr) public {
        for(uint256 i = 0; i < arr.length; i++) {
            uint256 a = arr[i];
        }
    }

    function test4(uint256[] memory arr) public {
        uint256 a;
        for(uint256 i = 0; i < arr.length; i++) {
            a = arr[i];
        }
    }
```