### PR TITLE
fix: pin all GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1
+      - uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
         with:
           node-version: ${{ matrix.node }}
 
@@ -25,7 +25,7 @@ jobs:
 
       - id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v1
+      - uses: actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7 # v1
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ matrix.os }}-yarn-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions in CI workflow to full-length commit SHAs to prevent supply chain attacks via tag mutation

## What changed
Replaced mutable tag references (`@v1`) with immutable commit SHA references for all three actions in `.github/workflows/CI.yml`:
- `actions/checkout@v1` -> `actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e`
- `actions/setup-node@v1` -> `actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e`
- `actions/cache@v1` -> `actions/cache@f5ce41475b483ad7581884324a6eca9f48f8dcc7`

Original tag names are preserved as inline comments for readability.

## Test plan
- [ ] CI workflow runs successfully on this PR

## Session context
Tags were resolved via `gh api repos/{owner}/{repo}/git/ref/tags/{tag}` and dereferenced for annotated tags (checkout@v1 was annotated, setup-node@v1 and cache@v1 were lightweight). No other workflow files or action references exist in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)